### PR TITLE
Fix wrong queue name in document

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -97,7 +97,7 @@ include::complete/src/main/java/hello/Application.java[]
 
 The `main()` method uses Spring Boot's `SpringApplication.run()` method to launch an application. Did you notice that there wasn't a single line of XML? No **web.xml** file either. This web application is 100% pure Java and you didn't have to deal with configuring any plumbing or infrastructure.
 
-The bean defined in the `listenerAdapter()` method is registered as a message listener in the container defined in `container()`. It will listen for messages on the "chat" queue. Because the `Receiver` class is a POJO, it needs to be wrapped in the `MessageListenerAdapter`, where you specify it to invoke `receiveMessage`.
+The bean defined in the `listenerAdapter()` method is registered as a message listener in the container defined in `container()`. It will listen for messages on the "spring-boot" queue. Because the `Receiver` class is a POJO, it needs to be wrapped in the `MessageListenerAdapter`, where you specify it to invoke `receiveMessage`.
 
 NOTE: JMS queues and AMQP queues have different semantics. For example, JMS sends queued messages to only one consumer. While AMQP queues do the same thing, AMQP producers don't send messages directly to queues. Instead, a message is sent to an exchange, which can go to a single queue, or fanout to multiple queues, emulating the concept of JMS topics. For more, see link:/understanding/AMQP[Understanding AMQP].
 
@@ -107,7 +107,7 @@ The `queue()` method creates an AMQP queue. The `exchange()` method creates a to
 
 NOTE: Spring AMQP requires that the `Queue`, the `TopicExchange`, and the `Binding` be declared as top level Spring beans in order to be set up properly.
 
-The `main()` method starts that process by creating a Spring application context. This starts the message listener container, which will start listening for messages. There is a `run()` method which is then automatically executed: it then retrieves the `RabbitTemplate` from the application context, waits five seconds, and sends a "Hello from RabbitMQ!" message on the "chat" queue. Finally, it closes the Spring application context and the application ends.
+The `main()` method starts that process by creating a Spring application context. This starts the message listener container, which will start listening for messages. There is a `run()` method which is then automatically executed: it then retrieves the `RabbitTemplate` from the application context, waits five seconds, and sends a "Hello from RabbitMQ!" message on the "spring-boot" queue. Finally, it closes the Spring application context and the application ends.
 
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/build_an_executable_jar_mainhead.adoc[]
 include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/master/build_an_executable_jar_with_both.adoc[]


### PR DESCRIPTION
I noticed that queue name in the document is wrong.
The queue name in the document is "chat", but name in source code is "spring-boot".
So I modified queue name in the document to "spring-boot".

