### PR TITLE
Display extracted Runner class in README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -94,6 +94,12 @@ Spring AMQP's `RabbitTemplate` provides everything you need to send and receive 
 
 NOTE: Spring Boot automatically creates a connection factory and a RabbitTemplate, reducing the amount of code you have to write.
 
+`src/main/java/hello/Runner.java`
+[source,java]
+----
+include::complete/src/main/java/hello/Runner.java[]
+----
+
 You'll use `RabbitTemplate` to send messages, and you will register a `Receiver` with the message listener container to receive messages. The connection factory drives both, allowing them to connect to the RabbitMQ server. 
 
 `src/main/java/hello/Application.java`


### PR DESCRIPTION
Functionality was extracted out of Application.java in this commit:
https://github.com/spring-guides/gs-messaging-rabbitmq/commit/16fea381f9a655a4357585bda80163fce84e2b6a

This adds a reference to the new Runner class to README.adoc so people following along with this guide know they need to create it for sending messages.