### PR TITLE
Modify README to use common instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -20,17 +20,7 @@ include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/
 == Setting up the RabbitMQ Broker
 
 Before you can build your messaging application, you need to set up a server to handle receiving and sending messages.
-This guide assumes that you use https://docs.spring.io/spring-boot/reference/features/dev-services.html#features.dev-services.docker-compose[Spring Boot Docker Compose support^].
-A prerequisite of this approach is that your development machine has a Docker environment, such as https://www.docker.com/products/docker-desktop/[Docker Desktop^], available.
-Add a dependency `spring-boot-docker-compose` that does the following:
-
-* Search for a compose.yml and other common compose filenames in your working directory
-* Call Docker compose up with the discovered compose.yml
-* Create service connection beans for each supported container
-* Call Docker compose stop when the application is shutdown
-
-To use Docker Compose support, you need only follow this guide.
-Based on the dependencies you pull in, Spring Boot finds the correct `compose.yml` file and start your Docker container when you run your application.
+include::https://raw.githubusercontent.com/spring-guides/getting-started-macros/main/docker_compose_support.adoc[]
 
 If you choose to run the RabbitMQ server yourself instead of using Spring Boot Docker Compose support, you have a few options:
 


### PR DESCRIPTION
Docker Compose support used in this guide is common to multiple Spring Guides. The description of Docker Compose Support in Spring Boot should be a common file that is referenced with a link instead of using the same text in multiple guides.

Linking to a shared file will make maintaining multiple guides easier and faster if the text can be modified in a single location.


**There should be no functional changes to the guide with this PR.**